### PR TITLE
add optional converting snake to camel case in request method and parameters

### DIFF
--- a/src/EdjCase.JsonRpc.Router/Configuration.cs
+++ b/src/EdjCase.JsonRpc.Router/Configuration.cs
@@ -26,5 +26,10 @@ namespace EdjCase.JsonRpc.Router
 		/// greater than the limit
 		/// </summary>
 		public int BatchRequestLimit { get; set; }
+
+		/// <summary>
+		/// Convert method name and parameters in request from snake case to camel case
+		/// </summary>
+		public bool ConvertSnakeCaseToCamelCaseInRequest { get; set; }
 	}
 }


### PR DESCRIPTION
For case when request have format:
{"jsonrpc": "2.0", "method": "get_object_list", "params": {"user_id": "123", "page": 1, "page_size": 100}, "id": 1}
-->>
And C# controller code have CamelCase format:
public MyObject[] GetObjectList(string userId, int page, int pageSize)