### PR TITLE
Fixes #54 JsonWriterException for Dictionary parameters

### DIFF
--- a/src/EdjCase.JsonRpc.Client/DefaultRequestSerializer.cs
+++ b/src/EdjCase.JsonRpc.Client/DefaultRequestSerializer.cs
@@ -226,7 +226,7 @@ namespace EdjCase.JsonRpc.Client
 						jsonWriter.WriteEndArray();
 						break;
 					case RpcParametersType.Dictionary:
-						jsonWriter.WriteEndObject();
+						jsonWriter.WriteStartObject();
 						foreach (KeyValuePair<string, object> value in request.Parameters.DictionaryValue)
 						{
 							jsonWriter.WritePropertyName(value.Key);


### PR DESCRIPTION
Serialization bug #54 looks like a simple typo. This seems to fix it.