### PR TITLE
fix method names matching, add test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ FakesAssemblies/
 # Visual Studio 6 workspace options file
 *.opt
 project.lock.json
+
+# Rider workspace options directory
+.idea

--- a/src/EdjCase.JsonRpc.Router/Utilities/RpcUtil.cs
+++ b/src/EdjCase.JsonRpc.Router/Utilities/RpcUtil.cs
@@ -42,7 +42,8 @@ namespace EdjCase.JsonRpc.Router.Utilities
 				return false;
 			}
 			//Make sure that it matched ALL the actual characters
-			return j == actual.Length;
+			//j - all iterations of comparing, need compare j with request.Length
+			return j == requested.Length;
 		}
 	}
 }

--- a/test/EdjCase.JsonRpc.Router.Tests/RpcUtilTests.cs
+++ b/test/EdjCase.JsonRpc.Router.Tests/RpcUtilTests.cs
@@ -1,0 +1,29 @@
+﻿using EdjCase.JsonRpc.Common;
+using EdjCase.JsonRpc.Router.Defaults;
+using Microsoft.Extensions.Options;
+using EdjCase.JsonRpc.Router.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using System.Threading.Tasks;
+using EdjCase.JsonRpc.Router.Utilities;
+
+namespace EdjCase.JsonRpc.Router.Tests
+{
+	public class RpcUtilTests
+	{
+		[Theory]
+		[InlineData("TestCase", "testcase")]
+		[InlineData("TestCase", "test_case")]
+		[InlineData("TestCase", "TEST_CASE")]
+		[InlineData("TestCase", "test-case")]
+		[InlineData("TestCase", "TEST-CASE")]
+		[InlineData("test", "Test")]
+		public async Task MatchMethodNamesTest(string methodInfo, string requestMethodName)
+		{
+			Assert.True(RpcUtil.NamesMatch(methodInfo, requestMethodName));
+		}
+	}
+}


### PR DESCRIPTION
Current version 4.0.3 not working with snake case name policy. Please approve this hotfix and redeploy nuget package.