### PR TITLE
Use invariant culture for method name comparison

### DIFF
--- a/src/EdjCase.JsonRpc.Router/Utilities/RpcUtil.cs
+++ b/src/EdjCase.JsonRpc.Router/Utilities/RpcUtil.cs
@@ -29,7 +29,7 @@ namespace EdjCase.JsonRpc.Router.Utilities
 			for (int i = 0; i < actual.Length; i++)
 			{
 				char requestedChar = requested[j++];
-				if (char.ToLower(actual[i]) == char.ToLower(requestedChar))
+				if (char.ToLowerInvariant(actual[i]) == char.ToLowerInvariant(requestedChar))
 				{
 					continue;
 				}

--- a/test/EdjCase.JsonRpc.Router.Tests/RpcUtilTests.cs
+++ b/test/EdjCase.JsonRpc.Router.Tests/RpcUtilTests.cs
@@ -25,5 +25,18 @@ namespace EdjCase.JsonRpc.Router.Tests
 		{
 			Assert.True(RpcUtil.NamesMatch(methodInfo, requestMethodName));
 		}
+
+		[Fact]
+		public void MatchMethodNamesCulturallyInvariantTest()
+		{
+			var previousCulture = System.Globalization.CultureInfo.CurrentCulture;
+			// Switch to a locale that would result in lowercasing 'I' to
+			// U+0131, if not done with invariant culture.
+			System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("az");
+			var methodInfo = "IsLunchTime";
+			var requestMethodName = "isLunchtIme";
+			Assert.True(RpcUtil.NamesMatch(methodInfo, requestMethodName));
+			System.Globalization.CultureInfo.CurrentCulture = previousCulture;
+		}
 	}
 }


### PR DESCRIPTION
To avoid failing to match API method names because of current culture
setting.

Case insensitive method matching is broken if the locale is set to az. For example, `isLunchTime` wouldn't match `IsLunchTime`. This PR changes the comparison from using char.ToLower to char.ToLowerInvariant.