### PR TITLE
bug fix

### DIFF
--- a/src/EdjCase.JsonRpc.Router/Utilities/RpcUtil.cs
+++ b/src/EdjCase.JsonRpc.Router/Utilities/RpcUtil.cs
@@ -26,11 +26,14 @@ namespace EdjCase.JsonRpc.Router.Utilities
 				return false;
 			}
 			int j = 0;
-			for (int i = 0; i < actual.Length; i++)
+			int equalsChars = 0;
+			for (int i = 0; i < actual.Length && j < requested.Length; i++)
 			{
 				char requestedChar = requested[j++];
-				if (char.ToLowerInvariant(actual[i]) == char.ToLowerInvariant(requestedChar))
+				char actualChar = actual[i];
+				if (char.ToLowerInvariant(actualChar) == char.ToLowerInvariant(requestedChar))
 				{
+					equalsChars++;
 					continue;
 				}
 				if (requestedChar == '-' || requestedChar == '_')
@@ -42,8 +45,8 @@ namespace EdjCase.JsonRpc.Router.Utilities
 				return false;
 			}
 			//Make sure that it matched ALL the actual characters
-			//j - all iterations of comparing, need compare j with request.Length
-			return j == requested.Length;
+			//j - all iterations of comparing, need compare j with actual.Length
+			return equalsChars == actual.Length;
 		}
 	}
 }

--- a/test/EdjCase.JsonRpc.Router.Tests/RpcUtilTests.cs
+++ b/test/EdjCase.JsonRpc.Router.Tests/RpcUtilTests.cs
@@ -25,6 +25,13 @@ namespace EdjCase.JsonRpc.Router.Tests
 		{
 			Assert.True(RpcUtil.NamesMatch(methodInfo, requestMethodName));
 		}
+		
+		[Theory]
+		[InlineData("GetUsers", "get_user")]
+		public void NotMatchMethodNamesTest(string methodInfo, string requestMethodName)
+		{
+			Assert.False(RpcUtil.NamesMatch(methodInfo, requestMethodName));
+		}
 
 		[Fact]
 		public void MatchMethodNamesCulturallyInvariantTest()


### PR DESCRIPTION
Hi @Gekctek, i get problem with names comparing helper.
Add test case when server crash (NotMatchMethodNamesTest), and return bad json, i found reason in names matcher, and fix this case.
Please publish new nuget package with this fix, even a stable version is possible because i test OnInvokeStart and OnInvokeEnd feature.
