### PR TITLE
Add auth in documentation/feature and fix method grouping in documentation by declaring type

### DIFF
--- a/src/EdjCase.JsonRpc.Router.Swagger/BuilderExtensions.cs
+++ b/src/EdjCase.JsonRpc.Router.Swagger/BuilderExtensions.cs
@@ -43,6 +43,7 @@ namespace EdjCase.JsonRpc.Router.Swagger.Extensions
 				.UseSwagger(configureSwagger)
 				.UseJsonRpc(configureRpc);
 		}
+
 		public static IApplicationBuilder UseJsonRpcWithSwaggerUI(this IApplicationBuilder app,
 			Action<RpcEndpointBuilder>? configureRpc = null,
 			Action<SwaggerOptions>? configureSwagger = null,
@@ -62,34 +63,33 @@ namespace EdjCase.JsonRpc.Router.Swagger.Extensions
 		{
 			return c =>
 			{
-				c.SwaggerDoc("v1", new OpenApiInfo
-				{
-					Title = "My API V1",
-					Version = "v1"
-				});
+				c.SwaggerDoc("v1", new OpenApiInfo {Title = "My API V1", Version = "v1"});
 
 				var authSchemaKey = "basicAuth";
-				c.AddSecurityDefinition(authSchemaKey, 
+				c.AddSecurityDefinition(authSchemaKey,
 					new OpenApiSecurityScheme()
 					{
 						In = ParameterLocation.Header,
 						Type = SecuritySchemeType.Http,
 						Scheme = "basic"
 					});
-				
+
 				c.AddSecurityRequirement(new OpenApiSecurityRequirement()
 				{
-					{new OpenApiSecurityScheme()
 					{
-						Reference = new OpenApiReference()
+						new OpenApiSecurityScheme()
 						{
-							Id	= authSchemaKey,
-							Type = ReferenceType.SecurityScheme
+							Reference = new OpenApiReference()
+							{
+								Id = authSchemaKey,
+								Type = ReferenceType.SecurityScheme
+							},
+							In = ParameterLocation.Header,
+							Name = "basic",
+							Scheme = "basic"
 						},
-						In = ParameterLocation.Header,
-						Name = "basic",
-						Scheme = "basic"
-					}, new List<string>()}
+						new List<string>()
+					}
 				});
 			};
 		}
@@ -97,7 +97,6 @@ namespace EdjCase.JsonRpc.Router.Swagger.Extensions
 		private static Action<SwaggerUIOptions> GetDefaultSwaggerUIOptions()
 		{
 			return c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
-			
 		}
 	}
 }

--- a/src/EdjCase.JsonRpc.Router.Swagger/BuilderExtensions.cs
+++ b/src/EdjCase.JsonRpc.Router.Swagger/BuilderExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,16 +60,44 @@ namespace EdjCase.JsonRpc.Router.Swagger.Extensions
 
 		private static Action<SwaggerGenOptions> GetDefaultSwaggerGenOptions()
 		{
-			return c => c.SwaggerDoc("v1", new OpenApiInfo
+			return c =>
 			{
-				Title = "My API V1",
-				Version = "v1"
-			});
+				c.SwaggerDoc("v1", new OpenApiInfo
+				{
+					Title = "My API V1",
+					Version = "v1"
+				});
+
+				var authSchemaKey = "basicAuth";
+				c.AddSecurityDefinition(authSchemaKey, 
+					new OpenApiSecurityScheme()
+					{
+						In = ParameterLocation.Header,
+						Type = SecuritySchemeType.Http,
+						Scheme = "basic"
+					});
+				
+				c.AddSecurityRequirement(new OpenApiSecurityRequirement()
+				{
+					{new OpenApiSecurityScheme()
+					{
+						Reference = new OpenApiReference()
+						{
+							Id	= authSchemaKey,
+							Type = ReferenceType.SecurityScheme
+						},
+						In = ParameterLocation.Header,
+						Name = "basic",
+						Scheme = "basic"
+					}, new List<string>()}
+				});
+			};
 		}
 
 		private static Action<SwaggerUIOptions> GetDefaultSwaggerUIOptions()
 		{
 			return c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+			
 		}
 	}
 }

--- a/src/EdjCase.JsonRpc.Router.Swagger/IXmlDocumentationService.cs
+++ b/src/EdjCase.JsonRpc.Router.Swagger/IXmlDocumentationService.cs
@@ -48,7 +48,8 @@ namespace EdjCase.JsonRpc.Router.Swagger
 
 		public string GetSummaryForMethod(IRpcMethodInfo methodInfo)
 		{
-			var methodNode = this.xpathNavigator.SelectSingleNode($"/doc/members/member[@name='{methodInfo.Name}']");
+			var methodMemberName = XmlCommentsNodeNameHelper.GetMemberNameForMethod(methodInfo.SourceMethodInfo);
+			var methodNode = this.xpathNavigator.SelectSingleNode($"/doc/members/member[@name='{methodMemberName}']");
 			var summaryNode = methodNode?.SelectSingleNode("summary");
 			return summaryNode != null ? XmlCommentsTextHelper.Humanize(summaryNode.InnerXml) : string.Empty;
 		}

--- a/src/EdjCase.JsonRpc.Router.Swagger/JsonRpcSwaggerProvider.cs
+++ b/src/EdjCase.JsonRpc.Router.Swagger/JsonRpcSwaggerProvider.cs
@@ -131,7 +131,7 @@ namespace EdjCase.JsonRpc.Router.Swagger
 		{
 			string methodAnnotation = this.xmlDocumentationService.GetSummaryForMethod(methodInfo);
 			Type trueReturnType = this.GetReturnType(methodInfo.RawReturnType);
-			var summaryForType = this.xmlDocumentationService.GetSummaryForType(methodInfo.DeclaringType);
+			var summaryForType = this.xmlDocumentationService.GetSummaryForType(methodInfo.SourceMethodInfo.DeclaringType);
 			var methodGroupAnatation = !string.IsNullOrWhiteSpace(summaryForType)
 				? summaryForType
 				: "Other";

--- a/src/EdjCase.JsonRpc.Router.Swagger/JsonRpcSwaggerProvider.cs
+++ b/src/EdjCase.JsonRpc.Router.Swagger/JsonRpcSwaggerProvider.cs
@@ -131,10 +131,17 @@ namespace EdjCase.JsonRpc.Router.Swagger
 		{
 			string methodAnnotation = this.xmlDocumentationService.GetSummaryForMethod(methodInfo);
 			Type trueReturnType = this.GetReturnType(methodInfo.RawReturnType);
+			var summaryForType = this.xmlDocumentationService.GetSummaryForType(methodInfo.DeclaringType);
+			var methodGroupAnatation = !string.IsNullOrWhiteSpace(summaryForType)
+				? summaryForType
+				: "Other";
 
 			return new OpenApiOperation()
 			{
-				Tags = new List<OpenApiTag>(),
+				Tags = new List<OpenApiTag>()
+				{
+					new OpenApiTag() {Name = methodGroupAnatation}
+				},
 				Summary = methodAnnotation,
 				RequestBody = this.GetOpenApiRequestBody(key, methodInfo, schemaRepository),
 				Responses = this.GetOpenApiResponses(key, trueReturnType, schemaRepository)

--- a/src/EdjCase.JsonRpc.Router.Swagger/Models/SwaggerConfiguration.cs
+++ b/src/EdjCase.JsonRpc.Router.Swagger/Models/SwaggerConfiguration.cs
@@ -4,7 +4,6 @@ namespace EdjCase.JsonRpc.Router.Swagger.Models
 {
 	public class SwaggerConfiguration
 	{
-		public string[] Endpoints { get; set; } = new string[0];
 		public JsonNamingPolicy NamingPolicy { get; set; } = JsonNamingPolicy.CamelCase;
 	}
 }

--- a/src/EdjCase.JsonRpc.Router/Abstractions/IRpcMethodProvider.cs
+++ b/src/EdjCase.JsonRpc.Router/Abstractions/IRpcMethodProvider.cs
@@ -27,11 +27,11 @@ namespace EdjCase.JsonRpc.Router.Abstractions
 	public interface IRpcMethodInfo
 	{
 		string Name { get; }
+		MethodInfo SourceMethodInfo { get; }
 		IReadOnlyList<IRpcParameterInfo> Parameters { get; }
 		bool AllowAnonymous { get; }
 		IReadOnlyList<IAuthorizeData> AuthorizeDataList { get; }
 		Type RawReturnType { get; }
-		Type DeclaringType { get; }
 		object? Invoke(object[] parameters, IServiceProvider serviceProvider);
 	}
 

--- a/src/EdjCase.JsonRpc.Router/Abstractions/IRpcMethodProvider.cs
+++ b/src/EdjCase.JsonRpc.Router/Abstractions/IRpcMethodProvider.cs
@@ -31,7 +31,7 @@ namespace EdjCase.JsonRpc.Router.Abstractions
 		bool AllowAnonymous { get; }
 		IReadOnlyList<IAuthorizeData> AuthorizeDataList { get; }
 		Type RawReturnType { get; }
-
+		Type DeclaringType { get; }
 		object? Invoke(object[] parameters, IServiceProvider serviceProvider);
 	}
 

--- a/src/EdjCase.JsonRpc.Router/RpcMethodInfo.cs
+++ b/src/EdjCase.JsonRpc.Router/RpcMethodInfo.cs
@@ -27,6 +27,8 @@ namespace EdjCase.JsonRpc.Router
 
 		public Type RawReturnType => this.methodInfo.ReturnType;
 
+		public Type DeclaringType => this.methodInfo.DeclaringType;
+
 		private DefaultRpcMethodInfo(
 			MethodInfo methodInfo,
 			IReadOnlyList<RpcParameterInfo> parameters,

--- a/src/EdjCase.JsonRpc.Router/RpcMethodInfo.cs
+++ b/src/EdjCase.JsonRpc.Router/RpcMethodInfo.cs
@@ -18,6 +18,7 @@ namespace EdjCase.JsonRpc.Router
 		private readonly MethodInfo methodInfo;
 		private readonly ObjectFactory objectFactory;
 		public string Name => this.methodInfo.Name;
+		public MethodInfo SourceMethodInfo => this.methodInfo;
 
 		public IReadOnlyList<IRpcParameterInfo> Parameters { get; }
 
@@ -26,8 +27,6 @@ namespace EdjCase.JsonRpc.Router
 		public IReadOnlyList<IAuthorizeData> AuthorizeDataList { get; }
 
 		public Type RawReturnType => this.methodInfo.ReturnType;
-
-		public Type DeclaringType => this.methodInfo.DeclaringType;
 
 		private DefaultRpcMethodInfo(
 			MethodInfo methodInfo,


### PR DESCRIPTION
a few more edits:
1) added to the documentation authorization (in the UI it will be possible to enter the login and password to access the api)
2) when merging, the grouping of methods by the controller was lost and its description was added for access method.DeclaringType