### PR TITLE
Magic eraise bytes in rpc parameters

### DIFF
--- a/src/EdjCase.JsonRpc.Router/Defaults/DefaultRpcInvoker.cs
+++ b/src/EdjCase.JsonRpc.Router/Defaults/DefaultRpcInvoker.cs
@@ -218,6 +218,8 @@ namespace EdjCase.JsonRpc.Router.Defaults
 							badParams.Add(parameterInfo);
 							continue;
 						}
+						//before first iteration, for parameter with key "text" array bytes contains vaules [34, 34]
+						//after first iteration, for parameter with key "text" array bytes contains values [0,0]
 						paramCache[i] = value!;
 					}
 					if (badParams != null)

--- a/src/EdjCase.JsonRpc.Router/Defaults/DefaultRpcParser.cs
+++ b/src/EdjCase.JsonRpc.Router/Defaults/DefaultRpcParser.cs
@@ -91,6 +91,7 @@ namespace EdjCase.JsonRpc.Router.Defaults
 				}
 				finally
 				{
+					//may be this code return memory, bytes magic eraises on next code use property "bytes" in object of type RpcParamter
 					ArrayPool<byte>.Shared.Return(jsonBytes, clearArray: false);
 				}
 

--- a/src/EdjCase.JsonRpc.Router/IRpcParameter.cs
+++ b/src/EdjCase.JsonRpc.Router/IRpcParameter.cs
@@ -87,13 +87,13 @@ namespace EdjCase.JsonRpc.Router
 	internal class JsonBytesRpcParameter : IRpcParameter
 	{
 		public RpcParameterType Type { get; }
-		private Memory<byte> bytes { get; }
+		private byte[] bytes { get; }
 		private JsonSerializerOptions? serializerOptions { get; }
 
 		public JsonBytesRpcParameter(RpcParameterType type, Memory<byte> bytes, JsonSerializerOptions? serializerOptions = null)
 		{
 			this.Type = type;
-			this.bytes = bytes;
+			this.bytes = bytes.ToArray();
 			this.serializerOptions = serializerOptions;
 		}
 
@@ -107,7 +107,7 @@ namespace EdjCase.JsonRpc.Router
 			
 			try
 			{
-				value = JsonSerializer.Deserialize(this.bytes.Span, type, this.serializerOptions);
+				value = JsonSerializer.Deserialize(this.bytes, type, this.serializerOptions);
 				return true;
 			}
 			catch (Exception)


### PR DESCRIPTION
Hi, i found case when property "bytes" magic eraise  in type RpcParameter.
In first commit i add test with case on response has error. In second commits i add fix and comments.
I think that after ending method ParseRequests, memory returning to OS, and all objects of type Memory<byte> created in this method may be changed in next external code scope.