### PR TITLE
[*] Disable Compression option

### DIFF
--- a/src/EdjCase.JsonRpc.Router/BuilderExtensions.cs
+++ b/src/EdjCase.JsonRpc.Router/BuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using EdjCase.JsonRpc.Router;
 using EdjCase.JsonRpc.Router.Abstractions;
 using EdjCase.JsonRpc.Router.Defaults;
@@ -43,7 +43,10 @@ namespace Microsoft.AspNetCore.Builder
 			{
 				throw new ArgumentNullException(nameof(serviceCollection));
 			}
-
+			if (configuration == null)
+			{
+				configuration = new RpcServerConfiguration();
+			}
 			serviceCollection.AddSingleton(new RpcServicesMarker());
 			serviceCollection
 				.TryAddScoped<IRpcInvoker, DefaultRpcInvoker>();
@@ -51,8 +54,11 @@ namespace Microsoft.AspNetCore.Builder
 				.TryAddScoped<IRpcParser, DefaultRpcParser>();
 			serviceCollection
 				.TryAddScoped<IRpcRequestHandler, RpcRequestHandler>();
-			serviceCollection
-				.TryAddScoped<IStreamCompressor, DefaultStreamCompressor>();
+			if (configuration.UseCompression)
+			{
+				serviceCollection
+					.TryAddScoped<IStreamCompressor, DefaultStreamCompressor>();
+			}
 			serviceCollection
 				.TryAddScoped<IRpcResponseSerializer, DefaultRpcResponseSerializer>();
 			serviceCollection
@@ -69,10 +75,7 @@ namespace Microsoft.AspNetCore.Builder
 				.TryAddSingleton<StaticRpcMethodDataAccessor>();
 			serviceCollection.AddHttpContextAccessor();
 
-			if (configuration == null)
-			{
-				configuration = new RpcServerConfiguration();
-			}
+			
 			return serviceCollection
 				.AddSingleton(Options.Create(configuration))
 				.AddRouting()

--- a/src/EdjCase.JsonRpc.Router/Configuration.cs
+++ b/src/EdjCase.JsonRpc.Router/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.Json;
 using EdjCase.JsonRpc.Router.Abstractions;
 
@@ -42,6 +42,11 @@ namespace EdjCase.JsonRpc.Router
 		/// If specified the router will call the specified method when the invoker has finished.
 		/// </summary>
 		public Action<RpcInvokeContext, RpcResponse>? OnInvokeEnd { get; set; }
+
+		/// <summary>
+		/// If true will support use Gzip and Deflate compression
+		/// </summary>
+		public bool UseCompression { get; set; } = true;
 	}
 
 	public class ExceptionContext


### PR DESCRIPTION
If i have multiple middlewares, a want use one compression setting for all middlewares.
For example:

```csharp

builder.Services.AddResponseCompression(option => .....);
...
app.UseCompression();
app.Use<Middlware1>();
app.UseJsonRpc(options => ....));
app.Use<Middlware2>();
```

Today i can disable internal EdjCase compressor with 
```
{    //Костыль отключает компрессию в  EdjCase
    var t = typeof(EdjCase.JsonRpc.Common.RpcError).Assembly.GetType("EdjCase.JsonRpc.Common.Tools.IStreamCompressor");
    builder.Services.AddScoped(t, sp => null);
}
```



